### PR TITLE
Improvements to hash computation definitions

### DIFF
--- a/draft-keytrans-mcmillion-protocol.md
+++ b/draft-keytrans-mcmillion-protocol.md
@@ -71,9 +71,7 @@ This document uses the TLS presentation language {{!RFC8446}} to describe the
 structure of protocol messages, but does not require the use of a specific
 transport protocol. As such, implementations do not necessarily need to transmit
 messages according to the TLS format and can chose whichever encoding method
-best suits their application. However, cryptographic computations MUST be done
-with the TLS presentation language format to ensure the protocol's security
-properties are maintained.
+best suits their application.
 
 
 # Tree Construction

--- a/draft-keytrans-mcmillion-protocol.md
+++ b/draft-keytrans-mcmillion-protocol.md
@@ -71,7 +71,9 @@ This document uses the TLS presentation language {{!RFC8446}} to describe the
 structure of protocol messages, but does not require the use of a specific
 transport protocol. As such, implementations do not necessarily need to transmit
 messages according to the TLS format and can chose whichever encoding method
-best suits their application.
+best suits their application. However, cryptographic computations MUST be done
+with the TLS presentation language format to ensure the protocol's security
+properties are maintained.
 
 
 # Tree Construction


### PR DESCRIPTION
Hi Brendan,

Two suggestions.

1. I made the recursion on the hash computation more explicit and gave also leaves the value field. I think this is clearer. The only downside is that you might need to store more information on disk, but the data structures will likely not be implemented like this anyways, no?
2. I dropped that cryptographic computations must be done with the TLS presentation language, because in the algorithms, you reference individual `opaque` fields only anyways. Will this change with the definition of other primitives? Could be. But so far, I thought that this sentence would only falsely lead people to believe that they must use TLS datastructures, ASN.1 parsers, etc., in the library whereas my understanding is that they need not do that.

Cheers!

Felix