### PR TITLE
Add aasvg dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "aasvg": "^0.4.0"
+  }
+}


### PR DESCRIPTION
Commit does the same as suggested here: https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/pull/142

With the change, I can run `make` locally to preview changes, see warnings, etc.