### PR TITLE
Tree node values

### DIFF
--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -1106,22 +1106,22 @@ is computed as follows.
 ~~~ pseudocode
 struct {
   opaque value[Hash.Nh];
-  optional<LogLeaf> leafData;
-  optional<LogTreeNode> leftChild;
-  optional<LogTreeNode> rightChild;
+  optional<LogLeaf> leaf_data;
+  optional<LogTreeNode> left_child;
+  optional<LogTreeNode> right_child;
 } LogTreeNode;
 
 log_node.value = logTreeValue(log_node)
 
 logTreeValue(node):
-  if node.leftChild == undefined && node.rightChild == undefined:
-    return Hash(node.leafData)
+  if node.left_child == undefined && node.right_child == undefined:
+    return Hash(node.leaf_data)
   else:
-    return Hash(logTreeHashContent(node.leftChild) ||
-                logTreeHashContent(node.rightChild))
+    return Hash(logTreeHashContent(node.left_child) ||
+                logTreeHashContent(node.right_child))
 
 logTreeHashContent(node):
-  if node.leftChild == undefined && node.rightChild == undefined:
+  if node.left_child == undefined && node.right_child == undefined:
     return 0x00 || node.value
   else:
     return 0x01 || node.value
@@ -1153,23 +1153,24 @@ is computed as follows.
 ~~~
 struct {
   opaque value[Hash.Nh];
-  optional<PrefixLeaf> leafData;
-  optional<PrefixNode> leftChild;
-  optional<PrefixNode> rightChild;
+  optional<PrefixLeaf> leaf_data;
+  optional<PrefixNode> left_child;
+  optional<PrefixNode> right_child;
 } PrefixNode;
 
-prefix_node.value = nodeValue(node)
+prefix_node.value = prefixTreeValue(node)
 
-nodeValue(node):
-  if node.type.leftChild == null && node.rightChild == null:
-    return Hash(node.leafData)
+prefixTreeValue(node):
+  if node.type.left_child == undefined && node.right_child == undefined:
+    return Hash(node.leaf_data)
   else:
-    return Hash(hashContent(node.leftChild) || hashContent(node.rightChild))
+    return Hash(prefixTreeHashContent(node.left_child) ||
+                prefixTreeHashContent(node.right_child))
 
-hashContent(node):
+prefixTreeHashContent(node):
   if node == undefined:
     return 0x00...0x00 // all-zero vector of length Hash.Nh+1
-  else if node.leftChild == null && node.rightChild == null:
+  else if node.left_child == undefined && node.right_child == undefined:
     return 0x01 || node.value
   else if node.type == parentNode:
     return 0x02 || node.value

--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -1133,21 +1133,33 @@ The `vrf_output` field contains the VRF output for the label-version pair.
 structure.
 
 The value of a parent node in the prefix tree is computed by hashing together
-the values of its left and right children:
+the values of its left and right children. Overall, a prefix tree node's value
+is computed as follows.
 
-~~~ pseudocode
-parent.value = Hash(hashContent(parent.leftChild) ||
-                    hashContent(parent.rightChild))
+~~~
+struct {
+  opaque value[Hash.Nh];
+  optional<PrefixLeaf> leafData;
+  optional<PrefixNode> leftChild;
+  optional<PrefixNode> rightChild;
+} PrefixNode;
+
+prefix_node.value = nodeValue(node)
+
+nodeValue(node):
+  if node.type.leftChild == null && node.rightChild == null:
+    return Hash(node.leafData)
+  else:
+    return Hash(hashContent(node.leftChild) || hashContent(node.rightChild))
 
 hashContent(node):
-  if node.type == emptyNode:
-    return 0 // all-zero vector of length Hash.Nh+1
-  else if node.type == leafNode:
+  if node == undefined:
+    return 0x00...0x00 // all-zero vector of length Hash.Nh+1
+  else if node.leftChild == null && node.rightChild == null:
     return 0x01 || node.value
   else if node.type == parentNode:
-    return 0x02 || node.value
+    return 0x02 || node.value
 ~~~
-
 
 # Tree Proofs
 

--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -1100,16 +1100,30 @@ milliseconds since the Unix epoch. The `prefix_tree` field contains the updated
 root hash of the prefix tree after making any desired modifications.
 
 The value of a parent node in the log tree is computed by hashing together the
-values of its left and right children:
+values of its left and right children. Overall, a log tree node's value
+is computed as follows.
 
 ~~~ pseudocode
-parent.value = Hash(hashContent(parent.leftChild) ||
-                    hashContent(parent.rightChild))
+struct {
+  opaque value[Hash.Nh];
+  optional<LogLeaf> leafData;
+  optional<LogTreeNode> leftChild;
+  optional<LogTreeNode> rightChild;
+} LogTreeNode;
 
-hashContent(node):
-  if node.type == leafNode:
+log_node.value = logTreeValue(log_node)
+
+logTreeValue(node):
+  if node.leftChild == undefined && node.rightChild == undefined:
+    return Hash(node.leafData)
+  else:
+    return Hash(logTreeHashContent(node.leftChild) ||
+                logTreeHashContent(node.rightChild))
+
+logTreeHashContent(node):
+  if node.leftChild == undefined && node.rightChild == undefined:
     return 0x00 || node.value
-  else if node.type == parentNode:
+  else:
     return 0x01 || node.value
 ~~~
 


### PR DESCRIPTION
PR provides a complete algorithm to determine a prefix and log tree node values.

Closes #27 and closes #28.

Related to #29 as I'm using `undefined` here.