### PR TITLE
Remove left_inclusion from monitoring_binary_ladder

### DIFF
--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -2855,9 +2855,9 @@ def search_binary_ladder(
 
 # Returns the set of versions that would be looked up in a monitoring binary
 # ladder where the monitored version of the label is t.
-def monitoring_binary_ladder(t, left_inclusion = []):
+def monitoring_binary_ladder(t):
     out = base_binary_ladder(t)
-    filtered_out = [v for v in out if v <= t and v not in left_inclusion]
+    filtered_out = [v for v in out if v <= t]
 
     return filtered_out
 ~~~


### PR DESCRIPTION
Fixes the appendix per your note in #48 — the parameter is a leftover from the
removed prose, so `monitoring_binary_ladder` now computes what §8.1 describes:
the series in §5 "omitting any lookup for a version greater than the target
version", and nothing else.

```diff
-def monitoring_binary_ladder(t, left_inclusion = []):
+def monitoring_binary_ladder(t):
     out = base_binary_ladder(t)
-    filtered_out = [v for v in out if v <= t and v not in left_inclusion]
+    filtered_out = [v for v in out if v <= t]
```

`search_binary_ladder`'s `left_inclusion` and `right_non_inclusion` are left
alone: §6.2 documents both optimizations for search ladders and §12.3 depends on
them.

Nothing else in the document referenced the parameter, so there is no prose to
follow up: §8.2 step 3.2 asks for "a monitoring binary ladder ... where the
target version is the version currently in the map" without mentioning a
deduplication set, and §12.3.4 just says a `PrefixProof` corresponding to one.

Checked against an implementation: this is the reading that interoperates. My
Rust client computes monitoring ladders with no deduplication and consumes
katie's contact-monitoring proofs exactly, over four recorded responses —
including one where a version had already been proven at an entry to the left,
which is where the two readings would have diverged.

Closes #48.